### PR TITLE
unicornのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :production do
+  gem 'unicorn'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -161,6 +162,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -222,6 +224,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -262,6 +267,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn
   web-console (>= 3.3.0)
 
 BUNDLED WITH

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,41 @@
+app_path = File.expand_path('../../', __FILE__)
+
+worker_processes 1
+
+working_directory app_path
+pid "#{app_path}/tmp/pids/unicorn.pid"
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+stdout_path "#{app_path}/log/unicorn.stdout.log"
+
+listen 3000
+timeout 60
+
+preload_app true
+GC.respond_to?(:copy_on_write_friendly=) && GC.copy_on_write_friendly = true
+
+check_client_connection false
+
+run_once = true
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+
+  if run_once
+    run_once = false # prevent from firing again
+  end
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exist?(old_pid) && server.pid != old_pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH => e
+      logger.error e
+    end
+  end
+end
+
+after_fork do |_server, _worker|
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
# WHAT
unicornのインストール。

# WHY
AWSにてデプロイする際のアプリケーションサーバを導入する必要があるため。